### PR TITLE
Improve mc dropout

### DIFF
--- a/gerumo/models/__init__.py
+++ b/gerumo/models/__init__.py
@@ -5,7 +5,7 @@ Models
 Custom models, meta-models, layers and loss funtions.
 
 """
-
+from .tools import *
 
 
 """

--- a/gerumo/models/tools.py
+++ b/gerumo/models/tools.py
@@ -11,7 +11,7 @@ __all__ = ['split_model']
 from tensorflow.keras.models import Model
 from tensorflow.keras.layers import Input
 
-def split_model(model, split_layer_name=None, split_layer_index=None, mc_dropout_layer_prefix=None):
+def split_model(model, split_layer_name=None, split_layer_index=None, mc_dropout_layer_prefix="bayesian_"):
     """
     Split a trained model for predictions.
 

--- a/gerumo/models/tools.py
+++ b/gerumo/models/tools.py
@@ -1,0 +1,56 @@
+"""
+Tools
+======
+
+Fix, debug or modify models
+"""
+
+
+__all__ = ['split_model']
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Input
+
+def split_model(model, split_layer_name=None, split_layer_index=None, mc_dropout_layer_prefix=None):
+    """
+    Split a trained model for predictions.
+
+    If `split_layer_name` and `split_layer_index` are both provided, `split_layer_index` will take precedence.
+    Indices are based on order of horizontal graph traversal (bottom-up).
+
+    Parameters
+    ----------
+    model : `tensorflow.keras.Model`
+        Source trained model.
+    split_layer_name : `str` or `None`
+        Name of layer to split model. 
+    split_layer_index : `int` or `None`
+        Telescope type.
+    Returns
+    =======
+        `tuple` of `tensorflow.keras.Model`
+        Encoder and Regressor models with source model's weigths.
+    """
+    # First model
+    split_layer_index = split_layer_index or model.layers.index(model.get_layer(split_layer_name))
+
+    encoder = Model(
+        model.input,
+        model.get_layer(index=split_layer_index).output
+    )
+    latent_variables_shape = encoder.output.shape[1:]
+    # Seconad model
+    x = regressor_input = Input(shape=latent_variables_shape)
+    for layer in model.layers[split_layer_index + 1:]:
+        if mc_dropout_layer_prefix is not None and\
+            mc_dropout_layer_prefix in layer.name:
+            x = layer(x, training=True)
+        else:
+            x = layer(x)
+    regressor = Model(regressor_input, x)
+    ## copy weights
+    for layer in regressor.layers[1:]:
+        layer.set_weights(
+            model.get_layer(name=layer.name).get_weights()
+        )
+    return encoder, regressor

--- a/tests/test_bmo.py
+++ b/tests/test_bmo.py
@@ -1,0 +1,67 @@
+import sys
+#FIX: this. re structuring the project
+sys.path.insert(1, '..')
+
+
+from gerumo import *
+import numpy as np
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Input
+import scipy.stats as st
+import timeit
+# configuration
+config={
+"telescope" : "MST_FlashCam",
+"image_mode": 'simple-shift',
+"image_mask":  True,
+"input_img_shape": INPUT_SHAPE["simple-shift-mask"]["MST_FlashCam"],
+"input_features_shape": (2,),
+"target_mode": "lineal",
+"targets": ["alt", "az"]
+}
+# architecture 
+model_extra_params =  {
+"latent_variables": 128,
+"conv_kernel_sizes": None,
+"compress_filters": 256,
+"compress_kernel_size": 3,
+"dense_layer_units": [128, 128, 64],
+"activity_regularizer_l1": None,
+"kernel_regularizer_l2": None,
+"dropout_rate": 0.5
+}
+sample_size = 50
+batch_size = 32
+number_of_runs=2
+
+# model and Ensembler
+model = bmo_unit(**config, **model_extra_params)
+bmo = BMO(mst_model_or_path=model)
+bmo.sample_size=sample_size
+
+# fake data
+batch_x = [
+    np.float32(np.random.random((batch_size, *INPUT_SHAPE["simple-shift-mask"]["MST_FlashCam"]))),
+    np.float32(np.random.random((batch_size, 2)))
+]
+
+predict_only = timeit.timeit(lambda: model.predict(batch_x), number=number_of_runs)
+print(f"predict one sample: {predict_only/2.0} [s]")
+
+old = timeit.timeit(lambda: bmo.bayesian_estimation_old(model, batch_x, bmo.sample_size, 0), number=number_of_runs)
+print(f"mc-dropout vanilla (sample size={sample_size}): {old/2.0} [s]")
+
+new_ = timeit.timeit(lambda: bmo.bayesian_estimation(model, batch_x, bmo.sample_size, 0), number=number_of_runs)
+print(f"mc-dropout new (sample size={sample_size}): {new_/2.0} [s]")
+new_2nd = timeit.timeit(lambda: bmo.bayesian_estimation(model, batch_x, bmo.sample_size, 0), number=number_of_runs)
+print(f"mc-dropout new (sample size={sample_size}) 2nd run: {new_2nd/2.0} [s]")
+
+old_10x = timeit.timeit(lambda: bmo.bayesian_estimation_old(model, batch_x, 10*bmo.sample_size, 0), number=number_of_runs//2)
+print(f"mc-dropout vanilla (sample size={10*sample_size}): {old_10x} [s]")
+
+new_10x = timeit.timeit(lambda: bmo.bayesian_estimation(model, batch_x, 10*sample_size, 0), number=number_of_runs)
+print(f"mc-dropout new (sample size={10*sample_size}): {new_10x/2.0} [s]")
+
+new_100x = timeit.timeit(lambda: bmo.bayesian_estimation(model, batch_x, 100*sample_size, 0), number=number_of_runs)
+print(f"mc-dropout new (sample size={100*sample_size}): {new_100x/2.0} [s]")
+


### PR DESCRIPTION
This method improves mc-dropout prediction time. 

Split model into deterministic and stochastic models, evaluate batch first in the deterministic model, and save stochastic latent variables. Then for each "row" in the latent variables batch, generate a new sampling batch by repeating the "row" `sample_size` times, and predict batch with de stochastics model.

Methods comparison:

<img width="359" alt="new_bayesian" src="https://user-images.githubusercontent.com/19175265/97806492-98abaa00-1c3a-11eb-9999-ac610b2ceaba.PNG">
